### PR TITLE
Use enumerate_names feature of RIAK 0.2.x

### DIFF
--- a/cleanreads.py
+++ b/cleanreads.py
@@ -54,6 +54,7 @@ class Decontamination:
             self.process = subprocess.Popen(
                 [
                     riak,
+                    "--enumerate_names",
                     "--ref_fasta",
                     ref_genome,
                     "--reads1",
@@ -72,6 +73,7 @@ class Decontamination:
             self.process = subprocess.Popen(
                 [
                     riak,
+                    "--enumerate_names",
                     "--ref_fasta",
                     ref_genome,
                     "--reads1",


### PR DESCRIPTION
Replace fastq header fields with enumerated integers as implemented in latest RIAK, preventing PII leakage and reducing compressed file size