### PR TITLE
Fix issue where ONT reads were RIAKed in Illumina mode

### DIFF
--- a/cleanreads.py
+++ b/cleanreads.py
@@ -50,10 +50,11 @@ class Decontamination:
                 raise GpasError()
             self.fq1 = Path(outdir) / f"{sample}.reads_1.fastq.gz"
             self.fq2 = Path(outdir) / f"{sample}.reads_2.fastq.gz"
-            # paired run
+            # paired end, assume illumina
             self.process = subprocess.Popen(
                 [
                     riak,
+                    "--tech illumina",
                     "--enumerate_names",
                     "--ref_fasta",
                     ref_genome,
@@ -68,11 +69,12 @@ class Decontamination:
                 stderr=subprocess.PIPE,
             )
         else:
-            # single end
+            # single end, assume ont
             self.fq1 = Path(outdir) / f"{sample}.reads.fastq.gz"
             self.process = subprocess.Popen(
                 [
                     riak,
+                    "--tech ont",
                     "--enumerate_names",
                     "--ref_fasta",
                     ref_genome,


### PR DESCRIPTION
Fixes https://github.com/GenomePathogenAnalysisService/gpas-uploader/issues/15

PRing sprint9 base since that seems to be where the action is happening, let me know if this is bad
