### PR TITLE
Fix for C900000008-600

### DIFF
--- a/gpas_uploader/UploadBatch.py
+++ b/gpas_uploader/UploadBatch.py
@@ -119,7 +119,9 @@ class UploadBatch:
             self.validation_errors = pandas.concat([self.validation_errors, pandas.DataFrame([[None, 'no sample_name column in upload CSV']], columns=['sample_name', 'error_message'])])
 
         elif any(self.df.sample_name.isna()):
-            self.validation_errors = pandas.concat([self.validation_errors, pandas.DataFrame([[None, 'sample_name cannot be empty']], columns=['sample_name', 'error_message'])])
+            for na in self.df.sample_name.isna():
+                if na:
+                    self.validation_errors = pandas.concat([self.validation_errors, pandas.DataFrame([[None, 'sample_name cannot be empty']], columns=['sample_name', 'error_message'])])
 
         elif len(self.df.sample_name.unique()) != len(self.df.sample_name):
             self.validation_errors = pandas.concat([self.validation_errors, pandas.DataFrame([[None, 'sample_name must be unique']], columns=['sample_name', 'error_message'])])


### PR DESCRIPTION
The actual pull request introduces a fix for https://oc-collab.gc3.ocs.oraclecloud.com/browse/C900000008-600.

The issue is that despite a metadata file can contain several rows with 'sample_name cannot be empty' validation error the output of validate command contains just one mention of it.

The actual changes add 'sample_name cannot be empty' validation error for each row which contains this error.
 